### PR TITLE
Add AccessDenied and generic error handlers

### DIFF
--- a/backend/src/main/java/com/budokan/dojoadmin/util/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/util/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.budokan.dojoadmin.util;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -28,9 +29,20 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Usuário inválido no token JWT");
     }
 
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException ex) {
+        Map<String, String> body = new HashMap<>();
+        body.put("errorCode", "FORBIDDEN");
+        body.put("message", "Acesso negado");
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
+    }
+
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<?> handleGeneric(Exception ex) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Erro interno: " + ex.getMessage());
+    public ResponseEntity<Map<String, String>> handleGeneric(Exception ex) {
+        Map<String, String> body = new HashMap<>();
+        body.put("errorCode", "INTERNAL_SERVER_ERROR");
+        body.put("message", "Erro interno: " + ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)


### PR DESCRIPTION
## Summary
- add handler for `AccessDeniedException`
- return JSON body for unhandled exceptions

## Testing
- `./mvnw -q test` *(fails: unable to download maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6862e027d2908321902087ab9a40d503