### PR TITLE
Endpoint para buscar aula por Sensei

### DIFF
--- a/backend/src/main/java/com/budokan/dojoadmin/controller/AulaController.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/controller/AulaController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/aulas")
@@ -66,6 +67,26 @@ public class AulaController {
         Pageable pageable = PageRequest.of(page, size, Sort.by("data").descending());
         Page<AulaResponseDTO> pageResult = aulaService.findByDateBetween(inicio, fim, pageable)
                 .map(aulaMapper::toDTO);
+        return ResponseEntity.ok(pageResult);
+    }
+
+    @GetMapping("/sensei/{id}")
+    public ResponseEntity<Page<AulaResponseDTO>> historicoPorSensei(@PathVariable UUID id,
+                                                                    @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate inicio,
+                                                                    @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fim,
+                                                                    @RequestParam(defaultValue = "0") int page,
+                                                                    @RequestParam(defaultValue = "10") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("data").descending());
+
+        Page<AulaResponseDTO> pageResult;
+        if (inicio != null && fim != null) {
+            pageResult = aulaService.findBySenseiAndDateBetween(id, inicio, fim, pageable)
+                    .map(aulaMapper::toDTO);
+        } else {
+            pageResult = aulaService.findBySensei(id, pageable)
+                    .map(aulaMapper::toDTO);
+        }
+
         return ResponseEntity.ok(pageResult);
     }
 

--- a/backend/src/main/java/com/budokan/dojoadmin/repository/AulaRepository.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/repository/AulaRepository.java
@@ -16,4 +16,7 @@ public interface AulaRepository extends JpaRepository<Aula, UUID> {
     List<Aula> findByData(LocalDate data);
     Page<Aula> findByDataBetween(LocalDate inicio, LocalDate fim, Pageable pageable);
 
+    Page<Aula> findBySenseiResponsavelId(UUID senseiId, Pageable pageable);
+    Page<Aula> findBySenseiResponsavelIdAndDataBetween(UUID senseiId, LocalDate inicio, LocalDate fim, Pageable pageable);
+
 }

--- a/backend/src/main/java/com/budokan/dojoadmin/service/AulaService.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/service/AulaService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/budokan/dojoadmin/service/AulaService.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/service/AulaService.java
@@ -38,5 +38,13 @@ public class AulaService {
         return aulaRepository.findByDataBetween(inicio, fim, pageable);
     }
 
+    public Page<Aula> findBySensei(UUID senseiId, Pageable pageable) {
+        return aulaRepository.findBySenseiResponsavelId(senseiId, pageable);
+    }
+
+    public Page<Aula> findBySenseiAndDateBetween(UUID senseiId, LocalDate inicio, LocalDate fim, Pageable pageable) {
+        return aulaRepository.findBySenseiResponsavelIdAndDataBetween(senseiId, inicio, fim, pageable);
+    }
+
 }
 


### PR DESCRIPTION
## Summary
- add repository queries for sensei history
- implement service methods to fetch classes by sensei with optional period
- expose `/aulas/sensei/{id}` endpoint in `AulaController`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631aad9d608321920b9caafe0d0008