### PR TITLE
Add frequency endpoint

### DIFF
--- a/backend/src/main/java/com/budokan/dojoadmin/dto/aula/FrequenciaDTO.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/dto/aula/FrequenciaDTO.java
@@ -1,0 +1,20 @@
+package com.budokan.dojoadmin.dto.aula;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FrequenciaDTO {
+
+    private long totalPresencas;
+    private double percentual;
+    private List<LocalDate> datas;
+}

--- a/backend/src/main/java/com/budokan/dojoadmin/repository/AulaRepository.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/repository/AulaRepository.java
@@ -16,4 +16,8 @@ public interface AulaRepository extends JpaRepository<Aula, UUID> {
     List<Aula> findByData(LocalDate data);
     Page<Aula> findByDataBetween(LocalDate inicio, LocalDate fim, Pageable pageable);
 
+    List<Aula> findByDataBetween(LocalDate inicio, LocalDate fim);
+
+    List<Aula> findByParticipantes_IdAndDataBetween(UUID alunoId, LocalDate inicio, LocalDate fim);
+
 }

--- a/backend/src/main/java/com/budokan/dojoadmin/service/AulaService.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/service/AulaService.java
@@ -1,6 +1,7 @@
 package com.budokan.dojoadmin.service;
 
 import com.budokan.dojoadmin.dto.aula.AulaRequestDTO;
+import com.budokan.dojoadmin.dto.aula.FrequenciaDTO;
 import com.budokan.dojoadmin.entity.Aula;
 import com.budokan.dojoadmin.mapper.AulaMapper;
 import com.budokan.dojoadmin.repository.AulaRepository;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +38,22 @@ public class AulaService {
 
     public Page<Aula> findByDateBetween(LocalDate inicio, LocalDate fim, Pageable pageable) {
         return aulaRepository.findByDataBetween(inicio, fim, pageable);
+    }
+
+    public FrequenciaDTO calcularFrequenciaAluno(UUID alunoId, LocalDate inicio, LocalDate fim) {
+        List<Aula> aulasPeriodo = aulaRepository.findByDataBetween(inicio, fim);
+        List<Aula> presencas = aulaRepository.findByParticipantes_IdAndDataBetween(alunoId, inicio, fim);
+
+        long totalPresencas = presencas.size();
+        double percentual = aulasPeriodo.isEmpty() ? 0.0 : (double) totalPresencas / aulasPeriodo.size() * 100;
+
+        List<LocalDate> datas = presencas.stream().map(Aula::getData).toList();
+
+        return FrequenciaDTO.builder()
+                .totalPresencas(totalPresencas)
+                .percentual(percentual)
+                .datas(datas)
+                .build();
     }
 
 }


### PR DESCRIPTION
## Summary
- implement `FrequenciaDTO`
- extend `AulaRepository` for attendance queries
- add calculation logic in `AulaService`
- expose new endpoint in `AlunoController`

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68631ab801c08321ae7327d1cc6afa66