### PR TITLE
Dashboard [backend]

### DIFF
--- a/backend/src/main/java/com/budokan/dojoadmin/controller/DashboardController.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/controller/DashboardController.java
@@ -1,0 +1,29 @@
+package com.budokan.dojoadmin.controller;
+
+import com.budokan.dojoadmin.dto.dashboard.DashboardResponseDTO;
+import com.budokan.dojoadmin.service.DashboardService;
+import com.budokan.dojoadmin.util.RoleUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/dashboard")
+@RequiredArgsConstructor
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    @GetMapping
+    public ResponseEntity<?> getDashboard(Authentication auth) {
+        if (!RoleUtil.isSensei(auth)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Sem permissão para executar ação");
+        }
+        DashboardResponseDTO dto = dashboardService.getDashboard();
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/backend/src/main/java/com/budokan/dojoadmin/dto/dashboard/DashboardResponseDTO.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/dto/dashboard/DashboardResponseDTO.java
@@ -1,0 +1,22 @@
+package com.budokan.dojoadmin.dto.dashboard;
+
+import com.budokan.dojoadmin.dto.aluno.AlunoPublicDTO;
+import com.budokan.dojoadmin.dto.mensalidade.MensalidadeResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DashboardResponseDTO {
+
+    private long totalAlunosAtivos;
+    private List<AlunoPublicDTO> proximosExames;
+    private List<MensalidadeResponseDTO> inadimplentes;
+    private List<AlunoPublicDTO> aniversariantes;
+}

--- a/backend/src/main/java/com/budokan/dojoadmin/repository/AlunoRepository.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/repository/AlunoRepository.java
@@ -15,9 +15,13 @@ import java.util.UUID;
 public interface AlunoRepository extends JpaRepository<Aluno, UUID> {
 
     List<Aluno> findByStatus(StatusAluno status);
+    long countByStatus(StatusAluno status);
     Optional<Aluno> findByUsuarioIgnoreCase(String username);
 
     @Query(value = "SELECT * FROM alunos WHERE unaccent(lower(nome)) LIKE unaccent(lower(concat('%', :nome, '%')))", nativeQuery = true)
     Optional<Aluno> findByNomeUnaccent(@Param("nome") String nome);
+
+    @Query("SELECT a FROM Aluno a WHERE a.status = :status AND FUNCTION('month', a.dataNascimento) = :mes")
+    List<Aluno> findAniversariantes(@Param("status") StatusAluno status, @Param("mes") int mes);
 
 }

--- a/backend/src/main/java/com/budokan/dojoadmin/service/DashboardService.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/service/DashboardService.java
@@ -1,0 +1,47 @@
+package com.budokan.dojoadmin.service;
+
+import com.budokan.dojoadmin.dto.dashboard.DashboardResponseDTO;
+import com.budokan.dojoadmin.dto.aluno.AlunoPublicDTO;
+import com.budokan.dojoadmin.dto.mensalidade.MensalidadeResponseDTO;
+import com.budokan.dojoadmin.enums.StatusPagamento;
+import com.budokan.dojoadmin.mapper.AlunoMapper;
+import com.budokan.dojoadmin.mapper.MensalidadeMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardService {
+
+    private final AlunoService alunoService;
+    private final MensalidadeService mensalidadeService;
+    private final AlunoMapper alunoMapper;
+    private final MensalidadeMapper mensalidadeMapper;
+
+    public DashboardResponseDTO getDashboard() {
+        long totalAtivos = alunoService.countActive();
+
+        List<AlunoPublicDTO> proximosExames = alunoService.findAptosExame()
+                .stream().map(alunoMapper::toPublicDTO).toList();
+
+        String mesAtual = YearMonth.now().format(DateTimeFormatter.ofPattern("yyyy/MM"));
+        List<MensalidadeResponseDTO> inadimplentes = mensalidadeService
+                .findByMesAndStatus(mesAtual, StatusPagamento.PENDENTE)
+                .stream().map(mensalidadeMapper::toDTO).toList();
+
+        int mesNumero = YearMonth.now().getMonthValue();
+        List<AlunoPublicDTO> aniversariantes = alunoService.findAniversariantes(mesNumero)
+                .stream().map(alunoMapper::toPublicDTO).toList();
+
+        return DashboardResponseDTO.builder()
+                .totalAlunosAtivos(totalAtivos)
+                .proximosExames(proximosExames)
+                .inadimplentes(inadimplentes)
+                .aniversariantes(aniversariantes)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/budokan/dojoadmin/util/GraduacaoHelper.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/util/GraduacaoHelper.java
@@ -33,4 +33,24 @@ public class GraduacaoHelper {
         return isDan(value) ? 100 + getDanLevel(value) : (11 - value); // Dan > Kyu
     }
 
+    /*
+     * retorna quantidade de meses mínima entre exames de acordo com a graduação.
+     * valores nulos indicam que não há controle (caso de faixas pretas)
+     */
+    public static Integer getMesesCarenciaExame(int value) {
+        if (isDan(value)) {
+            return null; // N/A para exames de Dan
+        }
+        if (value >= 6) { // 11º ao 6º kyu
+            return 3;
+        }
+        if (value >= 2) { // 5º ao 2º kyu
+            return 6;
+        }
+        if (value == 1) { // 1º kyu
+            return 12;
+        }
+        return null;
+    }
+
 }


### PR DESCRIPTION
## Summary
- add `DashboardController` and `DashboardService`
- return active students count, upcoming exams, defaulters and birthdays
- expose new repository methods on `AlunoRepository`
- expose helpers in `AlunoService`
- refine exam eligibility logic based on kyu

## Testing
- `./mvnw -q test` *(fails: failed to fetch maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68631af9f33c83219fef6901f22f547a