### PR TITLE
Implement dashboard features and enhance login

### DIFF
--- a/backend/src/main/java/com/budokan/dojoadmin/controller/ExameController.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/controller/ExameController.java
@@ -1,0 +1,29 @@
+package com.budokan.dojoadmin.controller;
+
+import com.budokan.dojoadmin.dto.exame.ExameResponseDTO;
+import com.budokan.dojoadmin.mapper.ExameMapper;
+import com.budokan.dojoadmin.service.ExameService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/exames")
+@RequiredArgsConstructor
+public class ExameController {
+
+    private final ExameService exameService;
+    private final ExameMapper exameMapper;
+
+    @GetMapping("/proximos")
+    public ResponseEntity<List<ExameResponseDTO>> listarProximos(@RequestParam(defaultValue = "30") int dias) {
+        List<ExameResponseDTO> dtos = exameService.findUpcoming(dias)
+                .stream().map(exameMapper::toDTO).toList();
+        return ResponseEntity.ok(dtos);
+    }
+}

--- a/backend/src/main/java/com/budokan/dojoadmin/dto/exame/ExameResponseDTO.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/dto/exame/ExameResponseDTO.java
@@ -1,0 +1,23 @@
+package com.budokan.dojoadmin.dto.exame;
+
+import com.budokan.dojoadmin.enums.Faixa;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExameResponseDTO {
+    private UUID id;
+    private String nomeAluno;
+    private LocalDate dataExame;
+    private int kyu;
+    private Faixa faixaAlvo;
+    private Boolean aprovado;
+}

--- a/backend/src/main/java/com/budokan/dojoadmin/mapper/ExameMapper.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/mapper/ExameMapper.java
@@ -1,0 +1,22 @@
+package com.budokan.dojoadmin.mapper;
+
+import com.budokan.dojoadmin.dto.exame.ExameResponseDTO;
+import com.budokan.dojoadmin.entity.Exame;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ExameMapper {
+
+    public ExameResponseDTO toDTO(Exame exame) {
+        return ExameResponseDTO.builder()
+                .id(exame.getId())
+                .nomeAluno(exame.getAluno() != null ? exame.getAluno().getNome() : null)
+                .dataExame(exame.getDataExame())
+                .kyu(exame.getKyu())
+                .faixaAlvo(exame.getFaixaAlvo())
+                .aprovado(exame.getAprovado())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/budokan/dojoadmin/service/ExameService.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/service/ExameService.java
@@ -1,0 +1,22 @@
+package com.budokan.dojoadmin.service;
+
+import com.budokan.dojoadmin.entity.Exame;
+import com.budokan.dojoadmin.repository.ExameRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ExameService {
+
+    private final ExameRepository exameRepository;
+
+    public List<Exame> findUpcoming(int daysAhead) {
+        LocalDate start = LocalDate.now();
+        LocalDate end = start.plusDays(daysAhead);
+        return exameRepository.findByDataExameBetween(start, end);
+    }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -25,6 +25,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -24,22 +24,25 @@ export default function Login() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
-      <form onSubmit={handleSubmit} className="bg-white p-8 rounded shadow max-w-xs w-full">
-        <h1 className="text-xl font-bold mb-6">Entrar</h1>
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-r from-blue-50 to-blue-100 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white p-8 rounded-xl shadow-lg w-full max-w-xs"
+      >
+        <h1 className="text-2xl font-bold mb-6 text-center text-gray-700">Entrar</h1>
         <input
-          className="w-full mb-3 p-2 border rounded"
+          className="w-full mb-4 p-2 border rounded focus:outline-none focus:ring"
           placeholder="Usuário"
           autoFocus
           value={username}
-          onChange={e => setUsername(e.target.value)}
+          onChange={(e) => setUsername(e.target.value)}
         />
         <input
-          className="w-full mb-3 p-2 border rounded"
+          className="w-full mb-4 p-2 border rounded focus:outline-none focus:ring"
           placeholder="Senha"
           type="password"
           value={password}
-          onChange={e => setPassword(e.target.value)}
+          onChange={(e) => setPassword(e.target.value)}
         />
         <button
           type="submit"


### PR DESCRIPTION
## Summary
- add new backend endpoint `/exames/proximos`
- create mapper, service and DTO for `Exame`
- load Tailwind via CDN and polish login layout
- fetch upcoming exams and pending payments on dashboard

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `./backend/mvnw -q test` *(fails: Maven repository fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686468498f988321b4eecad270ed3d00