### PR TITLE
Improve dashboard presentation

### DIFF
--- a/backend/src/main/java/com/budokan/dojoadmin/dto/exame/ExameResponseDTO.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/dto/exame/ExameResponseDTO.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 public class ExameResponseDTO {
+    private UUID alunoId;
     private String nomeAluno;
     private LocalDate dataExame;
     private int kyu;

--- a/backend/src/main/java/com/budokan/dojoadmin/mapper/ExameMapper.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/mapper/ExameMapper.java
@@ -11,6 +11,7 @@ public class ExameMapper {
 
     public ExameResponseDTO toDTO(Exame exame) {
         return ExameResponseDTO.builder()
+                .alunoId(exame.getAluno() != null ? exame.getAluno().getId() : null)
                 .nomeAluno(exame.getAluno() != null ? exame.getAluno().getNome() : null)
                 .dataExame(exame.getDataExame())
                 .kyu(exame.getKyu())

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,6 +33,7 @@ export default function App() {
           >
             <Route index element={<Dashboard />} />
             <Route path="alunos" element={<AlunoPage />} />
+            <Route path="alunos/:id" element={<AlunoPage />} />
             <Route path="mensalidades" element={<MensalidadePage />} />
             <Route path="aulas" element={<AulaPage />} />
           </Route>

--- a/frontend/src/components/ActiveStudents.jsx
+++ b/frontend/src/components/ActiveStudents.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import api from "../api";
 
 export default function ActiveStudents() {
@@ -24,20 +25,25 @@ export default function ActiveStudents() {
   if (error) return <p className="mt-4 text-center text-red-500">{error}</p>;
 
   return (
-    <section className="bg-white p-4 rounded shadow">
+    <section className="bg-white p-4 rounded shadow border border-[#E30C0C]">
       <h2 className="text-xl font-semibold mb-2">Alunos ativos</h2>
       {alunos.length === 0 ? (
         <p>Nenhum aluno ativo.</p>
       ) : (
-        <ul className="list-disc pl-5 space-y-1">
+        <ul className="space-y-2">
           {alunos.map((a) => (
-            <li key={a.id}>
-              {a.nome} - {a.graduacaoLabel} - {a.faixaAtual}
-              {a.dataNascimento && (
-                <> - {a.dataNascimento} - {a.dataUltimoExame}
-                  {a.observacoes && ` - ${a.observacoes}`}
-                </>
-              )}
+            <li key={a.id} className="flex flex-col sm:flex-row sm:space-x-2">
+              <Link
+                to={`/alunos/${a.id}`}
+                className="text-blue-600 underline"
+              >
+                {a.nome}
+              </Link>
+              <span>{a.graduacaoLabel}</span>
+              <span>{a.faixaAtual}</span>
+              {a.dataNascimento && <span>{a.dataNascimento}</span>}
+              {a.dataUltimoExame && <span>{a.dataUltimoExame}</span>}
+              {a.observacoes && <span>{a.observacoes}</span>}
             </li>
           ))}
         </ul>

--- a/frontend/src/components/PendingFees.jsx
+++ b/frontend/src/components/PendingFees.jsx
@@ -31,14 +31,18 @@ export default function PendingFees() {
   if (error) return <p className="mt-4 text-center text-red-500">{error}</p>;
 
   return (
-    <section className="bg-white p-4 rounded shadow">
+    <section className="bg-white p-4 rounded shadow border border-[#E30C0C]">
       <h2 className="text-xl font-semibold mb-2">Mensalidades pendentes</h2>
       {pendentes.length === 0 ? (
         <p>Nenhuma Mensalidade pendente.</p>
       ) : (
-        <ul className="list-disc pl-5 space-y-1">
+        <ul className="space-y-2">
           {pendentes.map((m) => (
-            <li key={m.id}>{`${m.nomeAluno} - ${m.mesReferencia} - ${m.statusPagamento}`}</li>
+            <li key={m.id} className="flex flex-col sm:flex-row sm:space-x-2">
+              <span>{m.nomeAluno}</span>
+              <span>{m.mesReferencia}</span>
+              <span>{m.statusPagamento}</span>
+            </li>
           ))}
         </ul>
       )}

--- a/frontend/src/components/UpcomingExams.jsx
+++ b/frontend/src/components/UpcomingExams.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import api from "../api";
 
 export default function UpcomingExams() {
@@ -9,7 +10,7 @@ export default function UpcomingExams() {
   useEffect(() => {
     async function load() {
       try {
-        const res = await api.get("/exames/proximos");
+        const res = await api.get("/exames/proximos?dias=30");
         setExames(res.data);
       } catch (err) {
         setError("Falha ao carregar exames");
@@ -24,14 +25,24 @@ export default function UpcomingExams() {
   if (error) return <p className="mt-4 text-center text-red-500">{error}</p>;
 
   return (
-    <section className="bg-white p-4 rounded shadow">
+    <section className="bg-white p-4 rounded shadow border border-[#E30C0C]">
       <h2 className="text-xl font-semibold mb-2">Próximos exames</h2>
       {exames.length === 0 ? (
         <p>Nenhum exame agendado.</p>
       ) : (
-        <ul className="list-disc pl-5 space-y-1">
-          {exames.map((e, idx) => (
-            <li key={idx}>{`${e.nomeAluno} - ${e.dataExame} - ${e.kyu}º kyu - ${e.faixaAlvo}`}</li>
+        <ul className="space-y-2">
+          {exames.map((e) => (
+            <li key={e.alunoId} className="flex flex-col sm:flex-row sm:space-x-2">
+              <Link
+                to={`/alunos/${e.alunoId}`}
+                className="text-blue-600 underline"
+              >
+                {e.nomeAluno}
+              </Link>
+              <span>{e.dataExame}</span>
+              <span>{e.kyu}º kyu</span>
+              <span>{e.faixaAlvo}</span>
+            </li>
           ))}
         </ul>
       )}

--- a/frontend/src/pages/AlunoPage.jsx
+++ b/frontend/src/pages/AlunoPage.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 import api from "../api";
 import AlunoForm from "../components/AlunoForm";
 import AlunoList from "../components/AlunoList";
@@ -6,6 +7,7 @@ import AlunoList from "../components/AlunoList";
 export default function AlunoPage() {
   const [alunos, setAlunos] = useState([]);
   const [editing, setEditing] = useState(null);
+  const { id } = useParams();
 
   const load = async () => {
     try {
@@ -19,6 +21,22 @@ export default function AlunoPage() {
   useEffect(() => {
     load();
   }, []);
+
+  useEffect(() => {
+    async function loadAluno() {
+      if (id) {
+        try {
+          const res = await api.get(`/alunos/id/${id}`);
+          setEditing(res.data);
+        } catch (err) {
+          console.error(err);
+        }
+      } else {
+        setEditing(null);
+      }
+    }
+    loadAluno();
+  }, [id]);
 
   const handleSave = async (data) => {
     if (editing) await api.put(`/alunos/${editing.id}`, data);


### PR DESCRIPTION
## Summary
- include alumnoId in `ExameResponseDTO`
- expose alumno id in exam mapper
- add route for editing a student by id
- load student data when opening route `/alunos/:id`
- restructure dashboard components to display object data without hyphens
- add project primary colour borders
- link dashboard lists to student page

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*
- `npm test --silent` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686a9f4f08a88321bac774575876d7c5