### PR TITLE
Melhorias no layout e listas de objetos

### DIFF
--- a/frontend/src/components/ActiveStudents.jsx
+++ b/frontend/src/components/ActiveStudents.jsx
@@ -32,18 +32,22 @@ export default function ActiveStudents() {
       ) : (
         <ul className="space-y-2">
           {alunos.map((a) => (
-            <li key={a.id} className="flex flex-col sm:flex-row sm:space-x-2">
+            <li key={a.id} className="space-y-1 border-b last:border-0 pb-2">
               <Link
                 to={`/alunos/${a.id}`}
-                className="text-blue-600 underline"
+                className="text-blue-600 underline block"
               >
                 {a.nome}
               </Link>
-              <span>{a.graduacaoLabel}</span>
-              <span>{a.faixaAtual}</span>
-              {a.dataNascimento && <span>{a.dataNascimento}</span>}
-              {a.dataUltimoExame && <span>{a.dataUltimoExame}</span>}
-              {a.observacoes && <span>{a.observacoes}</span>}
+              <span className="block">{a.graduacaoLabel}</span>
+              <span className="block">{a.faixaAtual}</span>
+              {a.dataNascimento && (
+                <span className="block">{a.dataNascimento}</span>
+              )}
+              {a.dataUltimoExame && (
+                <span className="block">{a.dataUltimoExame}</span>
+              )}
+              {a.observacoes && <span className="block">{a.observacoes}</span>}
             </li>
           ))}
         </ul>

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -6,7 +6,7 @@ export default function Layout() {
   return (
     <>
       <Navbar />
-      <div className="p-4">
+      <div className="p-4 mt-16">
         <Outlet />
       </div>
     </>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -9,7 +9,7 @@ export default function Navbar() {
     isActive ? "underline font-semibold" : "hover:underline";
 
   return (
-    <nav className="bg-[#E30C0C] text-white p-4 flex items-center justify-between">
+    <nav className="bg-[#E30C0C] text-white p-4 flex items-center justify-between fixed top-0 w-full z-10">
       <div className="flex items-center space-x-4">
         <NavLink to="/" className="mr-4 font-bold">
           Budokan

--- a/frontend/src/components/PendingFees.jsx
+++ b/frontend/src/components/PendingFees.jsx
@@ -38,10 +38,10 @@ export default function PendingFees() {
       ) : (
         <ul className="space-y-2">
           {pendentes.map((m) => (
-            <li key={m.id} className="flex flex-col sm:flex-row sm:space-x-2">
-              <span>{m.nomeAluno}</span>
-              <span>{m.mesReferencia}</span>
-              <span>{m.statusPagamento}</span>
+            <li key={m.id} className="space-y-1 border-b last:border-0 pb-2">
+              <span className="block">{m.nomeAluno}</span>
+              <span className="block">{m.mesReferencia}</span>
+              <span className="block">{m.statusPagamento}</span>
             </li>
           ))}
         </ul>

--- a/frontend/src/pages/AlunoPage.jsx
+++ b/frontend/src/pages/AlunoPage.jsx
@@ -46,7 +46,7 @@ export default function AlunoPage() {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="p-4 space-y-6 max-w-3xl mx-auto">
       <AlunoForm aluno={editing} onSubmit={handleSave} onCancel={() => setEditing(null)} />
       <AlunoList alunos={alunos} onEdit={setEditing} />
     </div>

--- a/frontend/src/pages/AulaPage.jsx
+++ b/frontend/src/pages/AulaPage.jsx
@@ -28,7 +28,7 @@ export default function AulaPage() {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="p-4 space-y-6 max-w-3xl mx-auto">
       <AulaForm onSubmit={handleCreate} />
       <AulaList aulas={aulas} />
     </div>

--- a/frontend/src/pages/MensalidadePage.jsx
+++ b/frontend/src/pages/MensalidadePage.jsx
@@ -27,7 +27,7 @@ export default function MensalidadePage() {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="p-4 space-y-6 max-w-3xl mx-auto">
       <MensalidadeForm
         mensalidade={editing}
         onSubmit={handleSave}


### PR DESCRIPTION
## Summary
- make Navbar fixed at the top
- adjust Layout padding to account for fixed Navbar
- centralize contents on Aula, Aluno and Mensalidade pages
- display attributes on separate lines in ActiveStudents and PendingFees

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*
- `./backend/mvnw -q test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_686aa6aa22ac83219a2b1ad22a274f39