### PR TITLE
Implement aula search filters and move form

### DIFF
--- a/backend/src/main/java/com/budokan/dojoadmin/controller/AulaController.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/controller/AulaController.java
@@ -90,5 +90,25 @@ public class AulaController {
         return ResponseEntity.ok(pageResult);
     }
 
+    @GetMapping("/aluno/{id}")
+    public ResponseEntity<Page<AulaResponseDTO>> historicoPorAluno(@PathVariable UUID id,
+                                                                   @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate inicio,
+                                                                   @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fim,
+                                                                   @RequestParam(defaultValue = "0") int page,
+                                                                   @RequestParam(defaultValue = "10") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("data").descending());
+
+        Page<AulaResponseDTO> pageResult;
+        if (inicio != null && fim != null) {
+            pageResult = aulaService.findByAlunoAndDateBetween(id, inicio, fim, pageable)
+                    .map(aulaMapper::toDTO);
+        } else {
+            pageResult = aulaService.findByAluno(id, pageable)
+                    .map(aulaMapper::toDTO);
+        }
+
+        return ResponseEntity.ok(pageResult);
+    }
+
 }
 

--- a/backend/src/main/java/com/budokan/dojoadmin/repository/AulaRepository.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/repository/AulaRepository.java
@@ -21,6 +21,9 @@ public interface AulaRepository extends JpaRepository<Aula, UUID> {
 
     List<Aula> findByParticipantes_IdAndDataBetween(UUID alunoId, LocalDate inicio, LocalDate fim);
 
+    Page<Aula> findByParticipantes_Id(UUID alunoId, Pageable pageable);
+    Page<Aula> findByParticipantes_IdAndDataBetween(UUID alunoId, LocalDate inicio, LocalDate fim, Pageable pageable);
+
 
     Page<Aula> findBySenseiResponsavelId(UUID senseiId, Pageable pageable);
     Page<Aula> findBySenseiResponsavelIdAndDataBetween(UUID senseiId, LocalDate inicio, LocalDate fim, Pageable pageable);

--- a/backend/src/main/java/com/budokan/dojoadmin/service/AulaService.java
+++ b/backend/src/main/java/com/budokan/dojoadmin/service/AulaService.java
@@ -65,5 +65,13 @@ public class AulaService {
         return aulaRepository.findBySenseiResponsavelIdAndDataBetween(senseiId, inicio, fim, pageable);
     }
 
+    public Page<Aula> findByAluno(UUID alunoId, Pageable pageable) {
+        return aulaRepository.findByParticipantes_Id(alunoId, pageable);
+    }
+
+    public Page<Aula> findByAlunoAndDateBetween(UUID alunoId, LocalDate inicio, LocalDate fim, Pageable pageable) {
+        return aulaRepository.findByParticipantes_IdAndDataBetween(alunoId, inicio, fim, pageable);
+    }
+
 }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import AlunoPage from "./pages/AlunoPage";
 import MensalidadePage from "./pages/MensalidadePage";
 import MensalidadeFormPage from "./pages/MensalidadeFormPage";
 import AulaPage from "./pages/AulaPage";
+import AulaFormPage from "./pages/AulaFormPage";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
@@ -39,6 +40,7 @@ export default function App() {
             <Route path="mensalidades/new" element={<MensalidadeFormPage />} />
             <Route path="mensalidades/:id" element={<MensalidadeFormPage />} />
             <Route path="aulas" element={<AulaPage />} />
+            <Route path="aulas/new" element={<AulaFormPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/frontend/src/components/AulaFilter.jsx
+++ b/frontend/src/components/AulaFilter.jsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from "react";
+import api from "../api";
+
+export default function AulaFilter({ onSearch }) {
+  const [tipo, setTipo] = useState("");
+  const [data, setData] = useState("");
+  const [senseiId, setSenseiId] = useState("");
+  const [alunoId, setAlunoId] = useState("");
+  const [alunos, setAlunos] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await api.get("/alunos/ativos");
+        setAlunos(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, []);
+
+  const blackBelts = alunos.filter((a) => a.graduacaoKyu >= 91);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSearch({ tipo, data, senseiId, alunoId });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 border p-4 max-w-md">
+      <h2 className="font-bold text-lg">Buscar Aulas</h2>
+      <label className="block">
+        <span className="text-sm">Buscar por</span>
+        <select
+          value={tipo}
+          onChange={(e) => setTipo(e.target.value)}
+          className="border p-2 w-full"
+        >
+          <option value="">Selecione</option>
+          <option value="dia">Dia</option>
+          <option value="sensei">Sensei</option>
+          <option value="aluno">Aluno</option>
+        </select>
+      </label>
+      {tipo === "dia" && (
+        <label className="block">
+          <span className="text-sm">Data</span>
+          <input
+            type="date"
+            value={data}
+            onChange={(e) => setData(e.target.value)}
+            className="border p-2 w-full"
+          />
+        </label>
+      )}
+      {tipo === "sensei" && (
+        <label className="block">
+          <span className="text-sm">Sensei</span>
+          <select
+            value={senseiId}
+            onChange={(e) => setSenseiId(e.target.value)}
+            className="border p-2 w-full"
+          >
+            <option value="">Selecione</option>
+            {blackBelts.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.nome}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+      {tipo === "aluno" && (
+        <label className="block">
+          <span className="text-sm">Aluno</span>
+          <select
+            value={alunoId}
+            onChange={(e) => setAlunoId(e.target.value)}
+            className="border p-2 w-full"
+          >
+            <option value="">Selecione</option>
+            {alunos.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.nome}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+      <button type="submit" className="bg-[#E30C0C] text-white px-4 py-1 rounded">
+        Buscar
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/AulaFilter.jsx
+++ b/frontend/src/components/AulaFilter.jsx
@@ -28,9 +28,9 @@ export default function AulaFilter({ onSearch }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2 border p-4 max-w-md">
+    <form onSubmit={handleSubmit} className="space-y-2 border p-4">
       <h2 className="font-bold text-lg">Buscar Aulas</h2>
-      <label className="block">
+      <label className="block max-w-md">
         <span className="text-sm">Buscar por</span>
         <select
           value={tipo}
@@ -44,7 +44,7 @@ export default function AulaFilter({ onSearch }) {
         </select>
       </label>
       {tipo === "dia" && (
-        <label className="block">
+        <label className="block max-w-md">
           <span className="text-sm">Data</span>
           <input
             type="date"
@@ -55,7 +55,7 @@ export default function AulaFilter({ onSearch }) {
         </label>
       )}
       {tipo === "sensei" && (
-        <label className="block">
+        <label className="block max-w-md">
           <span className="text-sm">Sensei</span>
           <select
             value={senseiId}
@@ -72,7 +72,7 @@ export default function AulaFilter({ onSearch }) {
         </label>
       )}
       {tipo === "aluno" && (
-        <label className="block">
+        <label className="block max-w-md">
           <span className="text-sm">Aluno</span>
           <select
             value={alunoId}
@@ -87,7 +87,7 @@ export default function AulaFilter({ onSearch }) {
             ))}
           </select>
         </label>
-      )}
+      )} <br/>
       <button type="submit" className="bg-[#E30C0C] text-white px-4 py-1 rounded">
         Buscar
       </button>

--- a/frontend/src/components/AulaForm.jsx
+++ b/frontend/src/components/AulaForm.jsx
@@ -23,9 +23,10 @@ export default function AulaForm({ onSubmit }) {
   const blackBelts = alunos.filter((a) => a.graduacaoKyu >= 91);
   const participantesOptions = alunos.filter((a) => a.id !== senseiId);
 
-  const handleParticipantesChange = (e) => {
-    const selected = Array.from(e.target.selectedOptions).map((o) => o.value);
-    setParticipantes(selected);
+  const handleParticipantesChange = (id) => {
+    setParticipantes((prev) =>
+      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id]
+    );
   };
 
   const handleSubmit = (e) => {
@@ -60,18 +61,20 @@ export default function AulaForm({ onSubmit }) {
         ))}
       </select> <br/> <br/>
       <span className="text-sm">Alunos</span>
-      <select
-        multiple
-        value={participantes}
-        onChange={handleParticipantesChange}
-        className="border p-2 w-full h-32"
-      >
+      <div className="border p-2 w-full h-32 overflow-y-auto">
         {participantesOptions.map((a) => (
-          <option key={a.id} value={a.id}>
+          <label key={a.id} className="block">
+            <input
+              type="checkbox"
+              value={a.id}
+              checked={participantes.includes(a.id)}
+              onChange={() => handleParticipantesChange(a.id)}
+              className="mr-2"
+            />
             {a.nome}
-          </option>
+          </label>
         ))}
-      </select>
+      </div>
       <input
         placeholder="URL da foto da aula"
         value={fotoUrl}

--- a/frontend/src/components/AulaList.jsx
+++ b/frontend/src/components/AulaList.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 
-export default function AulaList({ aulas }) {
+export default function AulaList({ aulas, title, page, totalPages, onPageChange }) {
   return (
     <div>
-      <h2 className="font-bold text-lg mb-2">Últimas Aulas</h2>
+      <h2 className="font-bold text-lg mb-2">{title}</h2>
       <table className="min-w-full border">
         <thead>
           <tr className="bg-gray-200">
@@ -22,6 +22,24 @@ export default function AulaList({ aulas }) {
           ))}
         </tbody>
       </table>
+      {totalPages > 1 && (
+        <div className="flex justify-between mt-2">
+          <button
+            disabled={page === 0}
+            onClick={() => onPageChange(page - 1)}
+            className="px-2 py-1 border rounded disabled:opacity-50"
+          >
+            Anterior
+          </button>
+          <button
+            disabled={page + 1 >= totalPages}
+            onClick={() => onPageChange(page + 1)}
+            className="px-2 py-1 border rounded disabled:opacity-50"
+          >
+            Próxima
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/AulaFormPage.jsx
+++ b/frontend/src/pages/AulaFormPage.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import api from "../api";
+import AulaForm from "../components/AulaForm";
+
+export default function AulaFormPage() {
+  const navigate = useNavigate();
+
+  const handleSave = async (data) => {
+    await api.post("/aulas", { ...data, data: data.data });
+    navigate("/aulas");
+  };
+
+  return (
+    <div className="p-4 max-w-3xl mx-auto">
+      <AulaForm onSubmit={handleSave} />
+    </div>
+  );
+}

--- a/frontend/src/pages/AulaPage.jsx
+++ b/frontend/src/pages/AulaPage.jsx
@@ -1,45 +1,81 @@
 import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import api from "../api";
 import AulaList from "../components/AulaList";
-import AulaForm from "../components/AulaForm";
+import AulaFilter from "../components/AulaFilter";
 
 export default function AulaPage() {
-  const [aulas, setAulas] = useState([]);
+  const [pageData, setPageData] = useState({ content: [], number: 0, totalPages: 0 });
+  const [filter, setFilter] = useState(null);
+  const navigate = useNavigate();
 
-  const load = async () => {
+  const loadMonth = async (page = 0) => {
+    const now = new Date();
+    const inicio = new Date(now.getFullYear(), now.getMonth(), 1)
+      .toISOString()
+      .slice(0, 10);
+    const fim = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+      .toISOString()
+      .slice(0, 10);
     try {
-      const res = await api.get("/aulas");
-      setAulas(res.data.content || res.data);
+      const res = await api.get(
+        `/aulas/periodo?inicio=${inicio}&fim=${fim}&page=${page}`
+      );
+      setPageData(res.data);
     } catch (err) {
       console.error(err);
     }
   };
 
   useEffect(() => {
-    load();
+    loadMonth();
   }, []);
 
-  const handleCreate = async (data) => {
-    await api.post("/aulas", {
-      ...data,
-      data: data.data,
-    });
-    load();
+  const handleSearch = async (params, page = 0) => {
+    try {
+      let url = "";
+      if (params.tipo === "dia" && params.data) {
+        url = `/aulas/periodo?inicio=${params.data}&fim=${params.data}&page=${page}`;
+      } else if (params.tipo === "sensei" && params.senseiId) {
+        url = `/aulas/sensei/${params.senseiId}?page=${page}`;
+      } else if (params.tipo === "aluno" && params.alunoId) {
+        url = `/aulas/aluno/${params.alunoId}?page=${page}`;
+      } else {
+        return;
+      }
+      const res = await api.get(url);
+      setPageData(res.data);
+      setFilter(params);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
+  const changePage = (p) => {
+    if (filter) handleSearch(filter, p);
+    else loadMonth(p);
+  };
+
+  const title = filter ? "Aulas encontradas" : "Últimas aulas do mês";
+
   return (
-    <div className="p-4 max-w-7xl mx-auto">
-      <div className="flex flex-col md:flex-row gap-20">
-        
-        <div className="flex flex-col flex-1">
-          <AulaForm onSubmit={handleCreate} />
-        </div>
-
-        <div className="flex flex-col flex-1 gap-6">
-          <AulaList aulas={aulas} />
-        </div>
-
+    <div className="p-4 max-w-7xl mx-auto space-y-6">
+      <div className="flex justify-end">
+        <button
+          onClick={() => navigate("/aulas/new")}
+          className="bg-[#E30C0C] text-white px-4 py-1 rounded"
+        >
+          Registrar
+        </button>
       </div>
+      <AulaFilter onSearch={(p) => handleSearch(p, 0)} />
+      <AulaList
+        aulas={pageData.content || []}
+        title={title}
+        page={pageData.number}
+        totalPages={pageData.totalPages}
+        onPageChange={changePage}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add pageable search by aluno on backend
- expose new endpoint `/aulas/aluno/{id}`
- support aluno search in service and repository
- change aula form to use checkboxes
- create AulaFilter component
- create AulaFormPage and route
- list only current month of aulas by default with pagination
- update AulaList for variable title and pagination

## Testing
- `./mvnw -q -DskipTests package` *(fails: Failed to fetch ...)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dad921e40832191345ef3eb25258f